### PR TITLE
Bug Fix: Missing inputs for test and publish action

### DIFF
--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -16,4 +16,8 @@ on:
 jobs:
   test-and-publish-charm:
     uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
+    with:
+      integration-test-extra-arguments: --cloud microk8s --jenkins-controller-name $(cat controller_name.txt) --jenkins-model-name $(cat model_name.txt) --jenkins-unit-number $(cat unit_number.txt)
+      integration-test-provider: 'microk8s'
+      integration-test-pre-run-script: files/pre-integration-test.sh
     secrets: inherit


### PR DESCRIPTION
The inputs for the `test_and_publish_charm.yaml` are missing.
These inputs are for integration testing part of the workflow.
The inputs should be the same as the `integration_test.yaml`.