### PR TITLE
Fix promote charm

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -23,4 +23,7 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
+      charm-base-name: 'ubuntu'
+      charm-base-channel: '22.04'
+      charm-base-architecture: 'amd64'
     secrets: inherit

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -23,7 +23,5 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
-      base-name: 'ubuntu'
       base-channel: '22.04'
-      base-architecture: 'amd64'
     secrets: inherit

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -23,7 +23,4 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
-      base-name: 'ubuntu'
-      base-channel: '22.04'
-      base-architecture: 'amd64'
     secrets: inherit

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -13,6 +13,9 @@ on:
         description: 'Destination Channel'
         options:
         - latest/stable
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
 
 jobs:
   promote-charm:

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -23,5 +23,4 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
-      base-channel: '22.04'
     secrets: inherit

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -23,7 +23,7 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
-      charm-base-name: 'ubuntu'
-      charm-base-channel: '22.04'
-      charm-base-architecture: 'amd64'
+      base-name: 'ubuntu'
+      base-channel: '22.04'
+      base-architecture: 'amd64'
     secrets: inherit

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -16,8 +16,11 @@ on:
 
 jobs:
   promote-charm:
-    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@promote-charm-base
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
+      base-name: 'ubuntu'
+      base-channel: '22.04'
+      base-architecture: 'amd64'
     secrets: inherit

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -16,4 +16,8 @@ on:
 jobs:
   test-and-publish-charm:
     uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
+    with:
+      integration-test-extra-arguments: --cloud microk8s --jenkins-controller-name $(cat controller_name.txt) --jenkins-model-name $(cat model_name.txt) --jenkins-unit-number $(cat unit_number.txt)
+      integration-test-provider: 'microk8s'
+      integration-test-pre-run-script: files/pre-integration-test.sh
     secrets: inherit


### PR DESCRIPTION
Jenkins agent k8s operator charm builds/runs on 22.04, however the default base setting for promote charm in operator-workflows is 20.04.

This PR adds the base settings for this charm.
