### PR TITLE
Add AnyHttpUrl validator for jenkins's server_url config field

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,0 @@
-# Ignore everything
-*
-
-# Include the files directory
-!files/*

--- a/jenkins_agent_k8s_rock/rockcraft.yaml
+++ b/jenkins_agent_k8s_rock/rockcraft.yaml
@@ -20,7 +20,7 @@ parts:
       - default-jre-headless
       - git
     override-prime: |
-      craftctl default  
+      craftctl default
       /bin/bash -c "mkdir -p --mode=775 var/{lib/jenkins,lib/jenkins/agents,log/jenkins}"
       /bin/bash -c "chown -R 584792 var/{lib/jenkins,lib/jenkins/agents,log/jenkins}"
   entrypoint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
 ignore_missing_imports = true
 check_untyped_defs = true
 disallow_untyped_defs = true
+plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/src/state.py
+++ b/src/state.py
@@ -38,6 +38,11 @@ class InvalidStateError(CharmStateBaseError):
         self.msg = msg
 
 class Validator(BaseModel):
+    """Pydantic validator for various attributes
+
+    Attrs:
+        http_url_validator: assign a value to this attribute to validate it against pydantic's HttpUrl type
+    """
     http_url_validator: HttpUrl
 
 class JenkinsConfig(BaseModel):
@@ -53,7 +58,16 @@ class JenkinsConfig(BaseModel):
 
     @validator("server_url")
     def valid_http_url(cls, server_url: str):
+        """Pydantic validator for sever_url attribute
+
+        Args:
+            server_url: the server_url attribute to validate
+
+        Returns:
+            the validated server_url attribute
+        """
         _ = Validator(http_url_validator = server_url)
+        return server_url
 
     @classmethod
     def from_charm_config(cls, config: ops.ConfigData) -> typing.Optional["JenkinsConfig"]:

--- a/src/state.py
+++ b/src/state.py
@@ -38,17 +38,6 @@ class InvalidStateError(CharmStateBaseError):
         self.msg = msg
 
 
-class Validator(BaseModel):
-    """Pydantic validator wrapper class for various attributes.
-
-    Attrs:
-        http_url_validator: assign a value to this attribute to validate it
-        against pydantic's AnyHttpUrl type.
-    """
-
-    http_url_validator: AnyHttpUrl
-
-
 class JenkinsConfig(BaseModel):
     """The Jenkins config from juju config values.
 

--- a/src/state.py
+++ b/src/state.py
@@ -9,7 +9,7 @@ import typing
 from dataclasses import dataclass
 
 import ops
-from pydantic import BaseModel, Field, ValidationError, validator, HttpUrl
+from pydantic import BaseModel, Field, ValidationError, validator, AnyHttpUrl
 
 import metadata
 import server
@@ -43,7 +43,7 @@ class Validator(BaseModel):
     Attrs:
         http_url_validator: assign a value to this attribute to validate it against pydantic's HttpUrl type
     """
-    http_url_validator: HttpUrl
+    http_url_validator: AnyHttpUrl
 
 class JenkinsConfig(BaseModel):
     """The Jenkins config from juju config values.

--- a/src/state.py
+++ b/src/state.py
@@ -42,7 +42,8 @@ class Validator(BaseModel):
     """Pydantic validator wrapper class for various attributes.
 
     Attrs:
-        http_url_validator: assign a value to this attribute to validate it against pydantic's AnyHttpUrl type.
+        http_url_validator: assign a value to this attribute to validate it
+        against pydantic's AnyHttpUrl type.
     """
 
     http_url_validator: AnyHttpUrl
@@ -60,7 +61,7 @@ class JenkinsConfig(BaseModel):
     agent_name_token_pairs: typing.List[typing.Tuple[str, str]] = Field(..., min_items=1)
 
     @validator("server_url")
-    def valid_http_url(cls, server_url: str):
+    def valid_http_url(self, server_url: str):
         """Pydantic validator for server_url attribute in jenkins' config.
 
         Args:
@@ -69,7 +70,7 @@ class JenkinsConfig(BaseModel):
         Returns:
             the validated server_url attribute.
         """
-        _ = Validator(http_url_validator = server_url)
+        _ = Validator(http_url_validator=server_url)
         return server_url
 
     @classmethod

--- a/src/state.py
+++ b/src/state.py
@@ -37,13 +37,16 @@ class InvalidStateError(CharmStateBaseError):
         """
         self.msg = msg
 
+
 class Validator(BaseModel):
-    """Pydantic validator for various attributes
+    """Pydantic validator wrapper class for various attributes
 
     Attrs:
-        http_url_validator: assign a value to this attribute to validate it against pydantic's HttpUrl type
+        http_url_validator: assign a value to this attribute to validate it against pydantic's AnyHttpUrl type
     """
+
     http_url_validator: AnyHttpUrl
+
 
 class JenkinsConfig(BaseModel):
     """The Jenkins config from juju config values.
@@ -58,7 +61,7 @@ class JenkinsConfig(BaseModel):
 
     @validator("server_url")
     def valid_http_url(cls, server_url: str):
-        """Pydantic validator for sever_url attribute
+        """Pydantic validator for server_url attribute in jenkins' config
 
         Args:
             server_url: the server_url attribute to validate
@@ -66,6 +69,7 @@ class JenkinsConfig(BaseModel):
         Returns:
             the validated server_url attribute
         """
+
         _ = Validator(http_url_validator = server_url)
         return server_url
 

--- a/src/state.py
+++ b/src/state.py
@@ -39,10 +39,10 @@ class InvalidStateError(CharmStateBaseError):
 
 
 class Validator(BaseModel):
-    """Pydantic validator wrapper class for various attributes
+    """Pydantic validator wrapper class for various attributes.
 
     Attrs:
-        http_url_validator: assign a value to this attribute to validate it against pydantic's AnyHttpUrl type
+        http_url_validator: assign a value to this attribute to validate it against pydantic's AnyHttpUrl type.
     """
 
     http_url_validator: AnyHttpUrl
@@ -61,13 +61,13 @@ class JenkinsConfig(BaseModel):
 
     @validator("server_url")
     def valid_http_url(cls, server_url: str):
-        """Pydantic validator for server_url attribute in jenkins' config
+        """Pydantic validator for server_url attribute in jenkins' config.
 
         Args:
-            server_url: the server_url attribute to validate
+            server_url: the server_url attribute to validate.
 
         Returns:
-            the validated server_url attribute
+            the validated server_url attribute.
         """
 
         _ = Validator(http_url_validator = server_url)

--- a/src/state.py
+++ b/src/state.py
@@ -9,7 +9,7 @@ import typing
 from dataclasses import dataclass
 
 import ops
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, validator, HttpUrl
 
 import metadata
 import server
@@ -37,6 +37,8 @@ class InvalidStateError(CharmStateBaseError):
         """
         self.msg = msg
 
+class Validator(BaseModel):
+    http_url_validator: HttpUrl
 
 class JenkinsConfig(BaseModel):
     """The Jenkins config from juju config values.
@@ -48,6 +50,10 @@ class JenkinsConfig(BaseModel):
 
     server_url: str = Field(..., min_length=1)
     agent_name_token_pairs: typing.List[typing.Tuple[str, str]] = Field(..., min_items=1)
+
+    @validator("server_url")
+    def valid_http_url(cls, server_url: str):
+        _ = Validator(http_url_validator = server_url)
 
     @classmethod
     def from_charm_config(cls, config: ops.ConfigData) -> typing.Optional["JenkinsConfig"]:

--- a/src/state.py
+++ b/src/state.py
@@ -61,7 +61,7 @@ class JenkinsConfig(BaseModel):
     agent_name_token_pairs: typing.List[typing.Tuple[str, str]] = Field(..., min_items=1)
 
     @validator("server_url")
-    def valid_http_url(self, server_url: str):
+    def valid_http_url(cls, server_url: str):
         """Pydantic validator for server_url attribute in jenkins' config.
 
         Args:

--- a/src/state.py
+++ b/src/state.py
@@ -69,7 +69,6 @@ class JenkinsConfig(BaseModel):
         Returns:
             the validated server_url attribute.
         """
-
         _ = Validator(http_url_validator = server_url)
         return server_url
 

--- a/src/state.py
+++ b/src/state.py
@@ -9,7 +9,7 @@ import typing
 from dataclasses import dataclass
 
 import ops
-from pydantic import BaseModel, Field, ValidationError, validator, AnyHttpUrl
+from pydantic import AnyHttpUrl, BaseModel, Field, ValidationError, validator
 
 import metadata
 import server

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -30,7 +30,7 @@ def harness_fixture():
 def config_fixture():
     """The Jenkins testing configuration values."""
     return {
-        "jenkins_url": "http://testingurl",
+        "jenkins_url": "http://testingurl.com",
         "jenkins_agent_name": "testing_agent_name",
         "jenkins_agent_token": secrets.token_hex(16),
     }

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -89,7 +89,7 @@ def test_from_charm_invalid_server_url(
         state.State.from_charm(charm=harness.charm)
 
 
-def test_from_charm_vailid_config(harness: ops.testing.Harness, config: typing.Dict[str, str]):
+def test_from_charm_valid_config(harness: ops.testing.Harness, config: typing.Dict[str, str]):
     """
     arrange: given valid charm configuration data.
     act: when the state is initialized from_charm.

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -75,9 +75,9 @@ def test_from_charm_invalid_server_url(
     harness: ops.testing.Harness, config: typing.Dict[str, str]
 ):
     """
-    arrange: given charm configuration data with invalid server_url attribute
+    arrange: given charm configuration data with invalid server_url attribute.
     act: when the state is initialized from_charm.
-    assert: InvalidStateError is raised. (due to pydantic's AnyHttpUrl validator)
+    assert: InvalidStateError is raised. (due to pydantic's AnyHttpUrl validator).
     """
     invalid_config = config
     # This configuration is invalid because schema (http or https) must be specified

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -71,6 +71,24 @@ def test_from_charm_invalid_charm_config(harness: ops.testing.Harness):
         state.State.from_charm(charm=harness.charm)
 
 
+def test_from_charm_invalid_server_url(
+    harness: ops.testing.Harness, config: typing.Dict[str, str]
+):
+    """
+    arrange: given charm configuration data with invalid server_url attribute
+    act: when the state is initialized from_charm.
+    assert: InvalidStateError is raised. (due to pydantic's AnyHttpUrl validator)
+    """
+    invalid_config = config
+    # This configuration is invalid because schema (http or https) must be specified
+    invalid_config["jenkins_url"] = "example.com"
+    harness.update_config(invalid_config)
+    harness.begin()
+
+    with pytest.raises(state.InvalidStateError):
+        state.State.from_charm(charm=harness.charm)
+
+
 def test_from_charm_vailid_config(harness: ops.testing.Harness, config: typing.Dict[str, str]):
     """
     arrange: given valid charm configuration data.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
