### PR TITLE
fix: agent defer

### DIFF
--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -50,14 +50,20 @@ Initialize a new instance of the InvalidStateError exception.
 ## <kbd>class</kbd> `JenkinsConfig`
 The Jenkins config from juju config values. 
 
-Attrs:  server_url: The Jenkins server url.  agent_name_token_pairs: Jenkins agent names paired with corresponding token value. 
+Attrs:  server_url_not_validated: The Jenkins server url, to be validated with pydantic.  server_url: The Jenkins server url, to be used by the charm.  agent_name_token_pairs: Jenkins agent names paired with corresponding token value. 
 
+
+---
+
+#### <kbd>property</kbd> server_url
+
+Convert validated server_url to string. 
 
 
 
 ---
 
-<a href="../src/state.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L59"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm_config`
 
@@ -91,7 +97,7 @@ Attrs:  agent_meta: The Jenkins agent metadata to register on Jenkins server.  j
 
 ---
 
-<a href="../src/state.py#L153"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -122,6 +122,8 @@ class Observer(ops.Object):
         if not self.state.slave_relation_credentials:
             self.charm.unit.status = ops.WaitingStatus("Waiting for complete relation data.")
             logger.info("Waiting for complete relation data.")
+            # The event needs to be retried after the agent credentials have been set.
+            event.defer()
             return
 
         self.charm.unit.status = ops.MaintenanceStatus("Downloading Jenkins agent executable.")
@@ -192,6 +194,8 @@ class Observer(ops.Object):
         if not self.state.agent_relation_credentials:
             self.charm.unit.status = ops.WaitingStatus("Waiting for complete relation data.")
             logger.info("Waiting for complete relation data.")
+            # The event needs to be retried after the agent credentials have been set.
+            event.defer()
             return
 
         self.charm.unit.status = ops.MaintenanceStatus("Downloading Jenkins agent executable.")
@@ -234,6 +238,7 @@ class Observer(ops.Object):
         """Handle slave relation departed event."""
         container = self.charm.unit.get_container(self.state.jenkins_agent_service_name)
         if not container.can_connect():
+            logger.warning("Relation departed before service ready.")
             return
         self.pebble_service.stop_agent(container=container)
         self.charm.unit.status = ops.BlockedStatus("Waiting for config/relation.")
@@ -242,6 +247,7 @@ class Observer(ops.Object):
         """Handle agent relation departed event."""
         container = self.charm.unit.get_container(self.state.jenkins_agent_service_name)
         if not container.can_connect():
+            logger.warning("Relation departed before service ready.")
             return
         self.pebble_service.stop_agent(container=container)
         self.charm.unit.status = ops.BlockedStatus("Waiting for config/relation.")


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Retry relation changed event after if credentials have not yet been set by the server charm.

### Rationale

<!-- The reason the change is needed -->
If deployed with terraform, all juju applications get deployed simultaneously, causing some relation data to be set later. The event should then be handled again using `event.defer()`.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
Retry relations that are not ready using `event.defer()`

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
`agent.py` now retries events that are not yet ready using `event.defer()`

### Library Changes

<!-- Any changes to charm libraries -->
None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
