### PR TITLE
update rocks entrypoint to use that of docker-inbound-agent

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,3 +9,6 @@ jobs:
     with:
       pre-run-script: tests/integration/pre_run_script.sh
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/jenkins_agent_k8s_rock/files/entrypoint.sh
+++ b/jenkins_agent_k8s_rock/files/entrypoint.sh
@@ -37,6 +37,10 @@ touch "${JENKINS_HOME}/agents/.ready"
 
 # Start Jenkins agent
 echo "${JENKINS_AGENT}"
-JENKINS_JAVA_BIN=$JAVA ${JENKINS_HOME}/jenkins-agent -url "${JENKINS_URL}" -secret "${JENKINS_TOKEN}" -name "${JENKINS_AGENT}" -noReconnect
+JENKINS_JAVA_BIN=$JAVA \
+JENKINS_URL="${JENKINS_URL}/computer/${JENKINS_AGENT}/jenkins-agent.jnlp" \
+JENKINS_NAME="${JENKINS_AGENT}" \
+JENKINS_SECRET="${JENKINS_TOKEN}" \
+${JENKINS_HOME}/jenkins-agent -noReconnect
 # Remove ready mark if unsuccessful
 rm ${JENKINS_HOME}/agents/.ready

--- a/jenkins_agent_k8s_rock/files/entrypoint.sh
+++ b/jenkins_agent_k8s_rock/files/entrypoint.sh
@@ -22,7 +22,7 @@ typeset JENKINS_URL="${JENKINS_URL:?"URL of a jenkins server must be provided"}"
 typeset JENKINS_AGENT="${JENKINS_AGENT:?"Jenkins agent name must be provided"}"
 typeset JENKINS_TOKEN="${JENKINS_TOKEN:?"Jenkins agent token must be provided"}"
 
-# typeset JENKINS_HOME="/var/lib/jenkins"
+# typeset JENKINS_HOME="/usr/share/jenkins"
 # homedir in jenkins-inbound-agent is fixed to /usr/share/jenkins
 typeset JENKINS_HOME="/usr/share/jenkins"
 mkdir -p "${JENKINS_HOME}/agents"

--- a/jenkins_agent_k8s_rock/files/entrypoint.sh
+++ b/jenkins_agent_k8s_rock/files/entrypoint.sh
@@ -36,7 +36,6 @@ touch "${JENKINS_HOME}/agents/.ready"
 
 # Start Jenkins agent
 echo "${JENKINS_AGENT}"
-${JAVA} -jar ${AGENT_JAR} -jnlpUrl "${JENKINS_URL}/computer/${JENKINS_AGENT}/slave-agent.jnlp" -workDir "${JENKINS_HOME}" -noReconnect -secret "${JENKINS_TOKEN}" || echo "Invalid or already used credentials."
-
+${JENKINS_HOME}/jenkins-agent -url "${JENKINS_URL}" -secret "${JENKINS_TOKEN}" -name ${JENKINS_AGENT} -noReconnect
 # Remove ready mark if unsuccessful
 rm ${JENKINS_HOME}/agents/.ready

--- a/jenkins_agent_k8s_rock/files/entrypoint.sh
+++ b/jenkins_agent_k8s_rock/files/entrypoint.sh
@@ -25,11 +25,11 @@ typeset JENKINS_TOKEN="${JENKINS_TOKEN:?"Jenkins agent token must be provided"}"
 # typeset JENKINS_HOME="/var/lib/jenkins"
 # homedir in jenkins-inbound-agent is fixed to /usr/share/jenkins
 typeset JENKINS_HOME="/usr/share/jenkins"
-
+mkdir -p "${JENKINS_HOME}/agents"
 # Ensure working directory is at $JENKINS_HOME
 # -workDir parameter might be unreliable from experiences
 # and jenkins can sometime ignore it (to be verified!)
-cd $JENKINS_HOME
+cd "${JENKINS_HOME}"
 # Path of the agent.jar
 typeset AGENT_JAR="${JENKINS_HOME}/agent.jar"
 

--- a/jenkins_agent_k8s_rock/files/entrypoint.sh
+++ b/jenkins_agent_k8s_rock/files/entrypoint.sh
@@ -31,7 +31,6 @@ mkdir -p "${JENKINS_HOME}/agents"
 # and jenkins can sometime ignore it (to be verified!)
 cd "${JENKINS_HOME}"
 # Path of the agent.jar
-typeset AGENT_JAR="${JENKINS_HOME}/agent.jar"
 
 # Specify the pod as ready
 touch "${JENKINS_HOME}/agents/.ready"

--- a/jenkins_agent_k8s_rock/files/entrypoint.sh
+++ b/jenkins_agent_k8s_rock/files/entrypoint.sh
@@ -22,7 +22,9 @@ typeset JENKINS_URL="${JENKINS_URL:?"URL of a jenkins server must be provided"}"
 typeset JENKINS_AGENT="${JENKINS_AGENT:?"Jenkins agent name must be provided"}"
 typeset JENKINS_TOKEN="${JENKINS_TOKEN:?"Jenkins agent token must be provided"}"
 
-typeset JENKINS_HOME="/var/lib/jenkins"
+# typeset JENKINS_HOME="/var/lib/jenkins"
+# homedir in jenkins-inbound-agent is fixed to /usr/share/jenkins
+typeset JENKINS_HOME="/usr/share/jenkins"
 
 # Ensure working directory is at $JENKINS_HOME
 # -workDir parameter might be unreliable from experiences
@@ -36,6 +38,6 @@ touch "${JENKINS_HOME}/agents/.ready"
 
 # Start Jenkins agent
 echo "${JENKINS_AGENT}"
-${JENKINS_HOME}/jenkins-agent -url "${JENKINS_URL}" -secret "${JENKINS_TOKEN}" -name ${JENKINS_AGENT} -noReconnect
+JENKINS_JAVA_BIN=$JAVA ${JENKINS_HOME}/jenkins-agent -url "${JENKINS_URL}" -secret "${JENKINS_TOKEN}" -name ${JENKINS_AGENT} -noReconnect
 # Remove ready mark if unsuccessful
 rm ${JENKINS_HOME}/agents/.ready

--- a/jenkins_agent_k8s_rock/files/entrypoint.sh
+++ b/jenkins_agent_k8s_rock/files/entrypoint.sh
@@ -38,6 +38,6 @@ touch "${JENKINS_HOME}/agents/.ready"
 
 # Start Jenkins agent
 echo "${JENKINS_AGENT}"
-JENKINS_JAVA_BIN=$JAVA ${JENKINS_HOME}/jenkins-agent -url "${JENKINS_URL}" -secret "${JENKINS_TOKEN}" -name ${JENKINS_AGENT} -noReconnect
+JENKINS_JAVA_BIN=$JAVA ${JENKINS_HOME}/jenkins-agent -url "${JENKINS_URL}" -secret "${JENKINS_TOKEN}" -name "${JENKINS_AGENT}" -noReconnect
 # Remove ready mark if unsuccessful
 rm ${JENKINS_HOME}/agents/.ready

--- a/jenkins_agent_k8s_rock/files/entrypoint.sh
+++ b/jenkins_agent_k8s_rock/files/entrypoint.sh
@@ -39,7 +39,6 @@ touch "${JENKINS_HOME}/agents/.ready"
 echo "${JENKINS_AGENT}"
 JENKINS_JAVA_BIN=$JAVA \
 JENKINS_URL="${JENKINS_URL}/computer/${JENKINS_AGENT}/jenkins-agent.jnlp" \
-JENKINS_NAME="${JENKINS_AGENT}" \
 JENKINS_SECRET="${JENKINS_TOKEN}" \
 ${JENKINS_HOME}/jenkins-agent -noReconnect
 # Remove ready mark if unsuccessful

--- a/jenkins_agent_k8s_rock/files/entrypoint.sh
+++ b/jenkins_agent_k8s_rock/files/entrypoint.sh
@@ -38,8 +38,7 @@ touch "${JENKINS_HOME}/agents/.ready"
 # Start Jenkins agent
 echo "${JENKINS_AGENT}"
 JENKINS_JAVA_BIN=$JAVA \
-JENKINS_URL="${JENKINS_URL}/computer/${JENKINS_AGENT}/jenkins-agent.jnlp" \
 JENKINS_SECRET="${JENKINS_TOKEN}" \
-${JENKINS_HOME}/jenkins-agent -noReconnect
+${JENKINS_HOME}/jenkins-agent -jnlpUrl "${JENKINS_URL}/computer/${JENKINS_AGENT}/jenkins-agent.jnlp" -noReconnect
 # Remove ready mark if unsuccessful
 rm ${JENKINS_HOME}/agents/.ready

--- a/jenkins_agent_k8s_rock/rockcraft.yaml
+++ b/jenkins_agent_k8s_rock/rockcraft.yaml
@@ -34,7 +34,7 @@ parts:
       entrypoint.sh: /usr/share/jenkins/entrypoint.sh
     override-prime: |
       craftctl default
-      /bin/bash -c "chmod +x var/lib/jenkins/entrypoint.sh"
+      /bin/bash -c "chmod +x usr/share/jenkins/entrypoint.sh"
   jenkins-agent-configure:
     plugin: nil
     after:

--- a/jenkins_agent_k8s_rock/rockcraft.yaml
+++ b/jenkins_agent_k8s_rock/rockcraft.yaml
@@ -22,11 +22,16 @@ parts:
     override-prime: |
       craftctl default
       /bin/bash -c "mkdir -p --mode=775 var/{lib/jenkins,lib/jenkins/agents,log/jenkins}"
-  entrypoint:
+  jenkins-agent-script:
     plugin: dump
     source: https://github.com/jenkinsci/docker-inbound-agent.git
     organize:
-      jenkins-agent: /var/lib/jenkins/entrypoint.sh
+      jenkins-agent: /var/lib/jenkins/jenkins-agent
+  entrypoint:
+    plugin: dump
+    source: files
+    organize:
+      entrypoint.sh: /var/lib/jenkins/entrypoint.sh
     override-prime: |
       craftctl default
       /bin/bash -c "chmod +x var/lib/jenkins/entrypoint.sh"
@@ -34,6 +39,7 @@ parts:
     plugin: nil
     after:
       - "jenkins"
+      - "jenkins-agent-script"
       - "entrypoint"
     override-prime: |
       craftctl default

--- a/jenkins_agent_k8s_rock/rockcraft.yaml
+++ b/jenkins_agent_k8s_rock/rockcraft.yaml
@@ -24,9 +24,9 @@ parts:
       /bin/bash -c "mkdir -p --mode=775 var/{lib/jenkins,lib/jenkins/agents,log/jenkins}"
   entrypoint:
     plugin: dump
-    source: files
+    source: https://github.com/jenkinsci/docker-inbound-agent.git
     organize:
-      entrypoint.sh: /var/lib/jenkins/entrypoint.sh
+      jenkins-agent: /var/lib/jenkins/entrypoint.sh
     override-prime: |
       craftctl default
       /bin/bash -c "chmod +x var/lib/jenkins/entrypoint.sh"

--- a/jenkins_agent_k8s_rock/rockcraft.yaml
+++ b/jenkins_agent_k8s_rock/rockcraft.yaml
@@ -26,12 +26,12 @@ parts:
     plugin: dump
     source: https://github.com/jenkinsci/docker-inbound-agent.git
     organize:
-      jenkins-agent: /var/lib/jenkins/jenkins-agent
+      jenkins-agent: /usr/share/jenkins/jenkins-agent
   entrypoint:
     plugin: dump
     source: files
     organize:
-      entrypoint.sh: /var/lib/jenkins/entrypoint.sh
+      entrypoint.sh: /usr/share/jenkins/entrypoint.sh
     override-prime: |
       craftctl default
       /bin/bash -c "chmod +x var/lib/jenkins/entrypoint.sh"

--- a/jenkins_agent_k8s_rock/rockcraft.yaml
+++ b/jenkins_agent_k8s_rock/rockcraft.yaml
@@ -21,7 +21,7 @@ parts:
       - git
     override-prime: |
       craftctl default
-      /bin/bash -c "mkdir -p --mode=775 var/{lib/jenkins,lib/jenkins/agents,log/jenkins}"
+      /bin/bash -c "mkdir -p --mode=775 usr/share/{jenkins,jenkins/agents} /var/log/jenkins"
   jenkins-agent-script:
     plugin: dump
     source: https://github.com/jenkinsci/docker-inbound-agent.git
@@ -43,4 +43,4 @@ parts:
       - "entrypoint"
     override-prime: |
       craftctl default
-      /bin/bash -c "chown -R 584792:584792 $CRAFT_PRIME/var/{lib/jenkins,log/jenkins}"
+      /bin/bash -c "chown -R 584792:584792 $CRAFT_PRIME/var/log/jenkins $CRAFT_PRIME/usr/share/jenkins"

--- a/jenkins_agent_k8s_rock/rockcraft.yaml
+++ b/jenkins_agent_k8s_rock/rockcraft.yaml
@@ -21,7 +21,7 @@ parts:
       - git
     override-prime: |
       craftctl default
-      /bin/bash -c "mkdir -p --mode=775 usr/share/{jenkins,jenkins/agents} /var/log/jenkins"
+      /bin/bash -c "mkdir -p --mode=775 usr/share/{jenkins,jenkins/agents} var/log/jenkins"
   jenkins-agent-script:
     plugin: dump
     source: https://github.com/jenkinsci/docker-inbound-agent.git

--- a/jenkins_agent_k8s_rock/rockcraft.yaml
+++ b/jenkins_agent_k8s_rock/rockcraft.yaml
@@ -4,7 +4,7 @@
 name: jenkins-agent-k8s
 summary: Jenkins-agent-k8s rock
 description: Jenkins-agent-k8s OCI image for the Jenkins-agent-k8s charm
-version: "1.1"
+version: "1.2"
 base: ubuntu:22.04
 build-base: ubuntu:22.04
 license: Apache-2.0

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -58,7 +58,7 @@ class PebbleService:
                 "ready": {
                     "override": "replace",
                     "level": "ready",
-                    "exec": {"command": "/bin/cat /var/lib/jenkins/agents/.ready"},
+                    "exec": {"command": "/bin/cat /usr/share/jenkins/agents/.ready"},
                     "period": "30s",
                     "threshold": 5,
                 }

--- a/src/server.py
+++ b/src/server.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
-JENKINS_WORKDIR = Path("/var/lib/jenkins")
+JENKINS_WORKDIR = Path("/usr/share/jenkins")
 AGENT_JAR_PATH = Path(JENKINS_WORKDIR / "agent.jar")
 AGENT_READY_PATH = Path(JENKINS_WORKDIR / "agents/.ready")
 ENTRYSCRIPT_PATH = Path(JENKINS_WORKDIR / "entrypoint.sh")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -133,9 +133,9 @@ def raise_exception_fixture():
 def jenkins_error_log_fixture():
     """The logs produced by Jenkins agent on failed connection."""
     return """<TIME_REDACTED> org.jenkinsci.remoting.engine.WorkDirManager initializeWorkDir
-INFO: Using /var/lib/jenkins/remoting as a remoting work directory
+INFO: Using /usr/share/jenkins/remoting as a remoting work directory
 <TIME_REDACTED> org.jenkinsci.remoting.engine.WorkDirManager setupLogging
-INFO: Both error and output logs will be printed to /var/lib/jenkins/remoting
+INFO: Both error and output logs will be printed to /usr/share/jenkins/remoting
 [Fatal Error] :1:1: Invalid byte 1 of 1-byte UTF-8 sequence.
 Exception in thread "main" org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1; Invalid byte 1 of 1-byte UTF-8 sequence.
     """
@@ -155,7 +155,7 @@ INFO: Setting up agent: jenkins-agent-k8s-0
 <TIME_REDACTED> hudson.remoting.Engine startEngine
 INFO: Using Remoting version: 3107.v665000b_51092
 <TIME_REDACTED> org.jenkinsci.remoting.engine.WorkDirManager initializeWorkDir
-INFO: Using /var/lib/jenkins/remoting as a remoting work directory
+INFO: Using /usr/share/jenkins/remoting as a remoting work directory
 <TIME_REDACTED> hudson.remoting.jnlp.Main$CuiListener status
 INFO: Locating server among [<IP_REDACTED>]
 <TIME_REDACTED> org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver resolve

--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,9 @@ commands =
 description = Run integration tests
 deps =
     pytest
+    # Pin protobuf version to fix
+    # https://stackoverflow.com/questions/72441758/typeerror-descriptors-cannot-not-be-created-directly
+    protobuf=3.20.0
     juju==3.0.4
     ops
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -104,10 +104,10 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest
     # Pin protobuf version to fix
     # https://stackoverflow.com/questions/72441758/typeerror-descriptors-cannot-not-be-created-directly
-    protobuf=3.20.0
+    protobuf==3.20.0
+    pytest
     juju==3.0.4
     ops
     pytest-operator


### PR DESCRIPTION
Currently the entry-point used for the jenkins k8s agent and the jenkins agent snap are custom scripts developed by IS charms, which is different from the official entrypoint of the (docker-inbound-agent](https://github.com/jenkinsci/docker-inbound-agent ) docker image. This script provides additional handlers for environment variables such as JENKINS_TUNNEL, JENKINS_DIRECT_CONNECT, etc.

Blind PR  to check tests.
### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
