### PR TITLE
fix: stop agent pebble svc not exist error & validate credentials error

### DIFF
--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -74,3 +74,9 @@ Stop Jenkins agent.
  - <b>`container`</b>:  The agent workload container. 
 
 
+
+**Raises:**
+ 
+ - <b>`APIError`</b>:  if something went wrong with pebble requesting service stop. 
+
+

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -74,9 +74,3 @@ Stop Jenkins agent.
  - <b>`container`</b>:  The agent workload container. 
 
 
-
-**Raises:**
- 
- - <b>`APIError`</b>:  if something went wrong with pebble requesting service stop. 
-
-

--- a/src/agent.py
+++ b/src/agent.py
@@ -207,22 +207,6 @@ class Observer(ops.Object):
             logger.error("Failed to download Jenkins agent executable, %s", exc)
             raise RuntimeError("Failed to download Jenkins agent.") from exc
 
-        self.charm.unit.status = ops.MaintenanceStatus("Validating credentials.")
-        if not server.validate_credentials(
-            agent_name=self.state.agent_meta.name,
-            credentials=self.state.agent_relation_credentials,
-            container=container,
-        ):
-            # The jenkins server sets credentials one by one, hence if the current credentials are
-            # not for this particular agent, the agent operator should wait until it receives one
-            # designated for it.
-            logger.warning(
-                "Failed credential for agent %s, will wait for next credentials to be set",
-                self.state.agent_meta.name,
-            )
-            self.charm.unit.status = ops.WaitingStatus("Waiting for credentials.")
-            return
-
         self.charm.unit.status = ops.MaintenanceStatus("Starting agent pebble service.")
         self.pebble_service.reconcile(
             server_url=self.state.agent_relation_credentials.address,

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -89,14 +89,12 @@ class PebbleService:
 
         Args:
             container: The agent workload container.
-
-        Raises:
-            APIError: if something went wrong with pebble requesting service stop.
         """
         try:
-            container.stop(self.state.jenkins_agent_service_name)
-        except ops.pebble.APIError as exc:
-            if f'service "{self.state.jenkins_agent_service_name}" does not exist' in exc.message:
-                return
-            raise
+            # use get_service to check if service should be stopped rather than stopping and
+            # catching ops.pebble.APIError and parsing error message to determine type of error.
+            container.get_service(self.state.jenkins_agent_service_name)
+        except ops.ModelError:
+            return
+        container.stop(self.state.jenkins_agent_service_name)
         container.remove_path(str(server.AGENT_READY_PATH))

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -89,6 +89,14 @@ class PebbleService:
 
         Args:
             container: The agent workload container.
+
+        Raises:
+            APIError: if something went wrong with pebble requesting service stop.
         """
-        container.stop(self.state.jenkins_agent_service_name)
+        try:
+            container.stop(self.state.jenkins_agent_service_name)
+        except ops.pebble.APIError as exc:
+            if f'service "{self.state.jenkins_agent_service_name}" does not exist' in exc.message:
+                return
+            raise
         container.remove_path(str(server.AGENT_READY_PATH))

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -271,17 +271,9 @@ def test_agent_relation_changed_download_jenkins_agent_fail(
         assert exc.value == "Failed to download Jenkins agent executable."
 
 
-@pytest.mark.parametrize(
-    "relation",
-    [
-        pytest.param(state.AGENT_RELATION, id="agent relation"),
-        pytest.param(state.SLAVE_RELATION, id="slave relation"),
-    ],
-)
 def test_agent_relation_changed_validate_credentials_fail(
     monkeypatch: pytest.MonkeyPatch,
     harness: ops.testing.Harness,
-    relation: str,
     get_event_relation_data: typing.Callable[
         [str], typing.Tuple[unittest.mock.MagicMock, typing.Dict[str, str]]
     ],
@@ -291,11 +283,11 @@ def test_agent_relation_changed_validate_credentials_fail(
     act: when _on_agent_relation_changed is called.
     assert: the unit falls into WaitingStatus.
     """
-    (mock_event, relation_data) = get_event_relation_data(relation)
+    (mock_event, relation_data) = get_event_relation_data(state.SLAVE_RELATION)
     monkeypatch.setattr(server, "download_jenkins_agent", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(server, "validate_credentials", lambda *_args, **_kwargs: False)
     harness.set_can_connect("jenkins-k8s-agent", True)
-    relation_id = harness.add_relation(relation, "jenkins")
+    relation_id = harness.add_relation(state.SLAVE_RELATION, "jenkins")
     harness.add_relation_unit(relation_id, "jenkins/0")
     harness.update_relation_data(
         relation_id=relation_id,
@@ -305,10 +297,7 @@ def test_agent_relation_changed_validate_credentials_fail(
     harness.begin()
 
     jenkins_charm = typing.cast(JenkinsAgentCharm, harness.charm)
-    if relation == state.AGENT_RELATION:
-        jenkins_charm.agent_observer._on_agent_relation_changed(mock_event)
-    else:
-        jenkins_charm.agent_observer._on_slave_relation_changed(mock_event)
+    jenkins_charm.agent_observer._on_slave_relation_changed(mock_event)
 
     assert jenkins_charm.unit.status.name == WAITING_STATUS_NAME
     assert jenkins_charm.unit.status.message == "Waiting for credentials."

--- a/tests/unit/test_pebble.py
+++ b/tests/unit/test_pebble.py
@@ -76,16 +76,12 @@ def test_stop_agent_service_not_exists():
     mock_state = unittest.mock.MagicMock(spec=state.State)
     mock_state.jenkins_agent_service_name = state.State.jenkins_agent_service_name
     mock_container = unittest.mock.MagicMock(spec=ops.Container)
-    mock_container.stop.side_effect = [
-        ops.pebble.APIError(
-            {}, 0, "", f'service "{state.State.jenkins_agent_service_name}" does not exist'
-        )
-    ]
+    mock_container.get_service.side_effect = [ops.ModelError()]
     pebble_service = pebble.PebbleService(state=mock_state)
 
     pebble_service.stop_agent(container=mock_container)
 
-    mock_container.stop.assert_called_once()
+    mock_container.stop.assert_not_called()
     mock_container.remove_path.assert_not_called()
 
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

1. Catches pebble API error when `pebble.stop(service)` has been called for services not yet instantiated.
2. Remove `validate_credentials` for agent relation since there is a concrete 1:1 mapping for agent relation. When validate credential fails due to Jenkins error, the event is not retried and the agent does not get registered at all in the end.
Example Jenkins error (somehow 404):
```
2024-01-02T01:29:57.224Z [container-agent] Exception in thread "main" java.io.IOException: Failed to obtain http://10.86.69.157:8080/computer/jenkins-agent-k8s-1/slave-agent.jnlp?encrypt=true
2024-01-02T01:29:57.224Z [container-agent] 	at hudson.remoting.Launcher.parseJnlpArguments(Launcher.java:567)
2024-01-02T01:29:57.224Z [container-agent] 	at hudson.remoting.Launcher.run(Launcher.java:346)
2024-01-02T01:29:57.224Z [container-agent] 	at hudson.remoting.Launcher.main(Launcher.java:297)
2024-01-02T01:29:57.224Z [container-agent] Caused by: java.io.IOException: Failed to load http://10.86.69.157:8080/computer/jenkins-agent-k8s-1/slave-agent.jnlp?encrypt=true: 404 Not Found
2024-01-02T01:29:57.224Z [container-agent] 	at hudson.remoting.Launcher.parseJnlpArguments(Launcher.java:514)
2024-01-02T01:29:57.224Z [container-agent] 	... 2 more
2024-01-02T01:29:57.224Z [container-agent]
```

### Rationale

1. This fails relation-broken event and falls into errored state.
2. Let pebble retry failing agent registration.

### Juju Events Changes

None.

### Module Changes

`pebble.py`'s `stop_agent` method now handles pebble API error for service not exists case.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
