### PR TITLE
feat: charm terraform module

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2025-09-08
+
+- feat: add terraform module
+
 ### 2025-03-11
+
 - docs: added changelog
 - chore: removed src-docs

--- a/terraform/charm/README.md
+++ b/terraform/charm/README.md
@@ -1,0 +1,59 @@
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
+# Jenkins-agent-k8s Terraform module
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
+
+This folder contains a base [Terraform][Terraform] module for the Jenkins-agent-k8s charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm
+deployment onto any Kubernetes environment managed by [Juju][Juju].
+
+## Module structure
+
+- **main.tf** - Defines the Juju application to be deployed.
+- **variables.tf** - Allows customization of the deployment. Also models the charm configuration, 
+  except for exposing the deployment options (Juju model name, channel or application name).
+- **outputs.tf** - Integrates the module with other Terraform modules, primarily
+  by defining potential integration endpoints (charm integrations), but also by exposing
+  the Juju application name.
+- **versions.tf** - Defines the Terraform provider version.
+
+## Using jenkins-agent-k8s base module in higher level modules
+
+If you want to use `jenkins-agent-k8s` base module as part of your Terraform module, import it
+like shown below:
+
+```text
+data "juju_model" "my_model" {
+  name = var.model
+}
+
+module "jenkins-agent-k8s" {
+  source = "git::https://github.com/canonical/jenkins-agent-k8s-operator//terraform"
+
+  model = juju_model.my_model.name
+  # (Customize configuration variables here if needed)
+}
+```
+
+Create integrations, for instance:
+
+```text
+resource "juju_integration" "jenkins-k8s-agent-agent-v0" {
+  model = juju_model.my_model.name
+  application {
+    name     = module.jenkins_k8s.app_name
+    endpoint = module.jenkins_k8s.requires.jenkins_agent_v0
+  }
+  application {
+    name     = "jenkins-agent-k8s"
+    endpoint = "agent"
+  }
+}
+```
+
+The complete list of available integrations can be found [in the Integrations tab][jenkins-agent-k8s-integrations].
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[Juju]: https://juju.is
+[jenkins-agent-k8s-integrations]: https://charmhub.io/jenkins-agent-k8s/integrations

--- a/terraform/charm/main.tf
+++ b/terraform/charm/main.tf
@@ -1,0 +1,18 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "jenkins_agent_k8s" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "jenkins-agent-k8s"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+}

--- a/terraform/charm/outputs.tf
+++ b/terraform/charm/outputs.tf
@@ -1,0 +1,13 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.jenkins_k8s.name
+}
+
+output "provides" {
+  value = {
+    agent = "jenkins_agent_v0"
+  }
+}

--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -1,0 +1,44 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "jenkins-agent-k8s"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "config" {
+  description = "Application config. Details about available options can be found at https://charmhub.io/jenkins-k8s/configurations"
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = ""
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+  default     = ""
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@22.04"
+}

--- a/terraform/charm/versions.tf
+++ b/terraform/charm/versions.tf
@@ -1,0 +1,11 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.22.0"
+    }
+  }
+}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Adds Jenkins agent terraform charm module
<!-- A high level overview of the change -->

### Rationale

- To deploy the charm via terraform
<!-- The reason the change is needed -->

### Juju events changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [docs/changelog](https://github.com/canonical/jenkins-agent-k8s-operator/docs/changelog.md) is updated.
<!-- Explanation for any unchecked items above -->
