### PR TITLE
fix: reconnect agent when server URL changes after upgrade/restart

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   integration-tests:
+    permissions:
+      contents: read
+      packages: write
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   unit-tests:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ venv
 !.vale/styles/config/vocabularies/local
 # END VALE WORKFLOW IGNORE
 
+.DS_Store

--- a/src/agent.py
+++ b/src/agent.py
@@ -81,17 +81,25 @@ class Observer(ops.Object):
             event.defer()
             return
 
-        # Check if the pebble service has started and set agent ready.
-        if container.exists(str(server.AGENT_READY_PATH)):
-            logger.warning("Given agent already registered. Skipping.")
-            return
-
         if not self.state.agent_relation_credentials:
             self.charm.unit.status = ops.WaitingStatus("Waiting for complete relation data.")
             logger.info("Waiting for complete relation data.")
             # The event needs to be retried after the agent credentials have been set.
             event.defer()
             return
+
+        # Check if the pebble service has started and set agent ready.
+        # If ready, verify the server URL hasn't changed (e.g. after server pod restart/upgrade).
+        if container.exists(str(server.AGENT_READY_PATH)):
+            if not self.pebble_service.credentials_changed(
+                container=container,
+                server_url=self.state.agent_relation_credentials.address,
+                agent_token=self.state.agent_relation_credentials.secret,
+            ):
+                logger.info("Agent registered with current credentials. No restart needed.")
+                return
+            logger.info("Server credentials changed. Restarting agent service.")
+            self.pebble_service.stop_agent(container=container)
 
         self.start_agent_from_relation(
             container=container,

--- a/src/agent.py
+++ b/src/agent.py
@@ -98,14 +98,31 @@ class Observer(ops.Object):
             ):
                 logger.info("Agent registered with current credentials. No restart needed.")
                 return
+            # Verify the new server is reachable before stopping the running agent.
+            # This prevents a window where the agent is down but the new server isn't ready.
+            if not server.server_is_ready(self.state.agent_relation_credentials.address):
+                logger.info(
+                    "Server at %s not yet reachable. Deferring.",
+                    self.state.agent_relation_credentials.address,
+                )
+                self.charm.unit.status = ops.WaitingStatus(
+                    "Waiting for new Jenkins server to become ready."
+                )
+                event.defer()
+                return
             logger.info("Server credentials changed. Restarting agent service.")
             self.pebble_service.stop_agent(container=container)
 
-        self.start_agent_from_relation(
-            container=container,
-            credentials=self.state.agent_relation_credentials,
-            agent_name=self.state.agent_meta.name,
-        )
+        try:
+            self.start_agent_from_relation(
+                container=container,
+                credentials=self.state.agent_relation_credentials,
+                agent_name=self.state.agent_meta.name,
+            )
+        except server.AgentJarDownloadError:
+            logger.warning("Failed to download agent.jar. Server may not be ready. Deferring.")
+            self.charm.unit.status = ops.WaitingStatus("Waiting for Jenkins server.")
+            event.defer()
 
     def start_agent_from_relation(
         self, container: ops.Container, credentials: server.Credentials, agent_name: str

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -84,6 +84,30 @@ class PebbleService:
         )
         container.replan()
 
+    def credentials_changed(
+        self, container: ops.Container, server_url: str, agent_token: str
+    ) -> bool:
+        """Check whether the pebble layer credentials differ from given values.
+
+        Args:
+            container: The agent workload container.
+            server_url: The Jenkins server URL to compare against.
+            agent_token: The agent secret token to compare against.
+
+        Returns:
+            True if the credentials have changed, False otherwise.
+        """
+        try:
+            plan = container.get_plan()
+        except (ops.pebble.ConnectionError, ops.ModelError):
+            return True
+        services = plan.services
+        agent_service = services.get(self.state.jenkins_agent_service_name)
+        if not agent_service:
+            return True
+        env = agent_service.environment or {}
+        return env.get("JENKINS_URL") != server_url or env.get("JENKINS_TOKEN") != agent_token
+
     def stop_agent(self, container: ops.Container) -> None:
         """Stop Jenkins agent.
 

--- a/src/server.py
+++ b/src/server.py
@@ -43,6 +43,26 @@ class AgentJarDownloadError(ServerBaseError):
     """Represents an error downloading agent JAR executable."""
 
 
+def server_is_ready(server_url: str, timeout: int = 5) -> bool:
+    """Check if the Jenkins server is reachable.
+
+    Performs a lightweight probe to verify the server can accept connections
+    before attempting heavier operations like downloading agent.jar.
+
+    Args:
+        server_url: The Jenkins server URL address.
+        timeout: Connection timeout in seconds.
+
+    Returns:
+        True if the server is reachable, False otherwise.
+    """
+    try:
+        resp = requests.get(f"{server_url}/login", timeout=timeout, allow_redirects=False)
+        return resp.status_code in (200, 403)
+    except (requests.ConnectionError, requests.Timeout):
+        return False
+
+
 def download_jenkins_agent(server_url: str, container: ops.Container) -> None:
     """Download Jenkins agent JAR executable from server.
 

--- a/tests/integration/test_agent_k8s.py
+++ b/tests/integration/test_agent_k8s.py
@@ -122,7 +122,7 @@ async def test_agent_reconnects_after_server_refresh(
         await model.relate(f"{application.name}:agent", f"{jenkins_k8s_server.name}:agent")
     await model.wait_for_idle(
         apps=[application.name, jenkins_k8s_server.name],
-        wait_for_active=True,
+        status="active",
         timeout=60 * 15,
     )
 
@@ -169,7 +169,7 @@ async def test_agent_reconnects_after_server_refresh(
     # Wait for the model to settle (agent charm should detect URL change and reconnect).
     await model.wait_for_idle(
         apps=[application.name, jenkins_k8s_server.name],
-        wait_for_active=True,
+        status="active",
         timeout=60 * 15,
         raise_on_error=False,
     )

--- a/tests/integration/test_agent_k8s.py
+++ b/tests/integration/test_agent_k8s.py
@@ -3,6 +3,7 @@
 
 """Integration tests for jenkins-agent-k8s-operator charm with k8s server."""
 
+import contextlib
 import logging
 
 import jenkinsapi.custom_exceptions
@@ -98,7 +99,10 @@ def _agent_is_online(client: jenkinsapi.jenkins.Jenkins, agent_name: str) -> boo
     try:
         node = client.get_node(agent_name)
         return node.is_online()
-    except (jenkinsapi.custom_exceptions.JenkinsAPIException, requests.exceptions.RequestException):
+    except (
+        jenkinsapi.custom_exceptions.JenkinsAPIException,
+        requests.exceptions.RequestException,
+    ):
         return False
 
 
@@ -114,10 +118,8 @@ async def test_agent_reconnects_after_server_refresh(
     assert: the agent automatically reconnects and comes back online.
     """
     # Ensure relation exists (may already be established from test_agent_recover).
-    try:
+    with contextlib.suppress(JujuError):  # Relation already exists from earlier test.
         await model.relate(f"{application.name}:agent", f"{jenkins_k8s_server.name}:agent")
-    except JujuError:
-        pass  # Relation already exists from earlier test.
     await model.wait_for_idle(
         apps=[application.name, jenkins_k8s_server.name],
         wait_for_active=True,
@@ -135,7 +137,10 @@ async def test_agent_reconnects_after_server_refresh(
     logger.info("Refreshing jenkins-k8s server charm...")
     await jenkins_k8s_server.refresh(channel="latest/edge")
     await model.wait_for_idle(
-        apps=[jenkins_k8s_server.name], timeout=60 * 15, raise_on_error=False, idle_period=30
+        apps=[jenkins_k8s_server.name],
+        timeout=60 * 15,
+        raise_on_error=False,
+        idle_period=30,
     )
 
     # Get new Jenkins server address after refresh.
@@ -148,8 +153,10 @@ async def test_agent_reconnects_after_server_refresh(
     # Find new server IP.
     status = await model.get_status([jenkins_k8s_server.name])
     server_app_status = status.applications[jenkins_k8s_server.name]
+    assert server_app_status is not None, "Server application status not found."
     server_unit_status = next(iter(server_app_status.units.values()))
-    new_address = server_unit_status.address
+    assert server_unit_status is not None, "Server unit status not found."
+    new_address = str(server_unit_status.address)
     logger.info("Jenkins server new address after refresh: %s", new_address)
 
     new_client = jenkinsapi.jenkins.Jenkins(

--- a/tests/integration/test_agent_k8s.py
+++ b/tests/integration/test_agent_k8s.py
@@ -5,9 +5,12 @@
 
 import logging
 
+import jenkinsapi.custom_exceptions
 import jenkinsapi.jenkins
 import kubernetes
+import requests.exceptions
 from juju.application import Application
+from juju.errors import JujuError
 from juju.model import Model
 from juju.unit import Unit
 
@@ -80,3 +83,96 @@ async def test_agent_run_sudo(
 
     assert action.results["return-code"] == 0, action.results["stderr"]
     assert "NOPASSWD" in action.results["stdout"]
+
+
+def _agent_is_online(client: jenkinsapi.jenkins.Jenkins, agent_name: str) -> bool:
+    """Check if agent node is online.
+
+    Args:
+        client: Jenkins API client.
+        agent_name: The agent node name.
+
+    Returns:
+        True if the agent is online.
+    """
+    try:
+        node = client.get_node(agent_name)
+        return node.is_online()
+    except (jenkinsapi.custom_exceptions.JenkinsAPIException, requests.exceptions.RequestException):
+        return False
+
+
+async def test_agent_reconnects_after_server_refresh(
+    model: Model,
+    application: Application,
+    jenkins_k8s_server: Application,
+    jenkins_client: jenkinsapi.jenkins.Jenkins,
+):
+    """
+    arrange: given a jenkins-agent-k8s charm related to jenkins-k8s server with agent online.
+    act: when the Jenkins server charm is refreshed (simulating a pod restart / URL change).
+    assert: the agent automatically reconnects and comes back online.
+    """
+    # Ensure relation exists (may already be established from test_agent_recover).
+    try:
+        await model.relate(f"{application.name}:agent", f"{jenkins_k8s_server.name}:agent")
+    except JujuError:
+        pass  # Relation already exists from earlier test.
+    await model.wait_for_idle(
+        apps=[application.name, jenkins_k8s_server.name],
+        wait_for_active=True,
+        timeout=60 * 15,
+    )
+
+    agent_unit: Unit = next(iter(application.units))
+    pod_name = agent_unit.name.replace("/", "-")
+
+    # Verify agent is initially online.
+    node: jenkinsapi.node.Node = jenkins_client.get_node(pod_name)
+    assert node.is_online(), f"Agent {pod_name} should be online before server refresh"
+
+    # Refresh the Jenkins server charm to trigger pod restart / IP change.
+    logger.info("Refreshing jenkins-k8s server charm...")
+    await jenkins_k8s_server.refresh(channel="latest/edge")
+    await model.wait_for_idle(
+        apps=[jenkins_k8s_server.name], timeout=60 * 15, raise_on_error=False, idle_period=30
+    )
+
+    # Get new Jenkins server address after refresh.
+    server_unit: Unit = next(iter(jenkins_k8s_server.units))
+    action = await server_unit.run_action("get-admin-password")
+    await action.wait()
+    assert action.status == "completed", "Failed to get credentials after refresh."
+    new_password = action.results["password"]
+
+    # Find new server IP.
+    status = await model.get_status([jenkins_k8s_server.name])
+    server_app_status = status.applications[jenkins_k8s_server.name]
+    server_unit_status = next(iter(server_app_status.units.values()))
+    new_address = server_unit_status.address
+    logger.info("Jenkins server new address after refresh: %s", new_address)
+
+    new_client = jenkinsapi.jenkins.Jenkins(
+        baseurl=f"http://{new_address}:8080",
+        username="admin",
+        password=new_password,
+        timeout=60,
+    )
+
+    # Wait for the model to settle (agent charm should detect URL change and reconnect).
+    await model.wait_for_idle(
+        apps=[application.name, jenkins_k8s_server.name],
+        wait_for_active=True,
+        timeout=60 * 15,
+        raise_on_error=False,
+    )
+
+    # Wait for agent to come back online on the new Jenkins instance.
+    await wait_for(
+        lambda: _agent_is_online(new_client, pod_name),
+        timeout=60 * 10,
+        check_interval=10,
+    )
+
+    node = new_client.get_node(pod_name)
+    assert node.is_online(), f"Agent {pod_name} should be online after server refresh"

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -133,7 +133,9 @@ def test_agent_relation_changed_service_running(
     relation_id = harness.add_relation(state.AGENT_RELATION, "jenkins")
     harness.add_relation_unit(relation_id, "jenkins/0")
     harness.update_relation_data(
-        relation_id, "jenkins/0", {"url": "http://10.1.69.130:8080", "jenkins-agent-k8s-0_secret": "token123"}
+        relation_id,
+        "jenkins/0",
+        {"url": "http://10.1.69.130:8080", "jenkins-agent-k8s-0_secret": "token123"},
     )
     monkeypatch.setattr(
         pebble.PebbleService, "credentials_changed", lambda *_args, **_kwargs: creds_changed

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -142,6 +142,7 @@ def test_agent_relation_changed_service_running(
     )
     monkeypatch.setattr(pebble.PebbleService, "stop_agent", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(server, "download_jenkins_agent", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "server_is_ready", lambda *_args, **_kwargs: True)
     harness.begin()
 
     jenkins_charm = typing.cast(JenkinsAgentCharm, harness.charm)
@@ -151,6 +152,40 @@ def test_agent_relation_changed_service_running(
         assert jenkins_charm.unit.status.name == ACTIVE_STATUS_NAME
     else:
         mock_event.defer.assert_not_called()
+
+
+def test_agent_relation_changed_server_not_ready(
+    harness: ops.testing.Harness,
+    monkeypatch: pytest.MonkeyPatch,
+    get_mock_relation_changed_event: typing.Callable[[str], unittest.mock.MagicMock],
+):
+    """
+    arrange: given an agent running with old credentials and server not reachable at new URL.
+    act: when relation changed event is triggered with new server URL.
+    assert: event is deferred and agent continues running on old credentials.
+    """
+    mock_event = get_mock_relation_changed_event(state.AGENT_RELATION)
+    harness.set_can_connect("jenkins-agent-k8s", True)
+    container = harness.model.unit.get_container("jenkins-agent-k8s")
+    container.push(server.AGENT_READY_PATH, "test", encoding="utf-8", make_dirs=True)
+    relation_id = harness.add_relation(state.AGENT_RELATION, "jenkins")
+    harness.add_relation_unit(relation_id, "jenkins/0")
+    harness.update_relation_data(
+        relation_id,
+        "jenkins/0",
+        {"url": "http://10.1.69.130:8080", "jenkins-agent-k8s-0_secret": "token123"},
+    )
+    monkeypatch.setattr(
+        pebble.PebbleService, "credentials_changed", lambda *_args, **_kwargs: True
+    )
+    monkeypatch.setattr(server, "server_is_ready", lambda *_args, **_kwargs: False)
+    harness.begin()
+
+    jenkins_charm = typing.cast(JenkinsAgentCharm, harness.charm)
+    jenkins_charm.agent_observer._on_agent_relation_changed(mock_event)
+
+    assert jenkins_charm.unit.status.name == WAITING_STATUS_NAME
+    mock_event.defer.assert_called_once()
 
 
 def test_agent_relation_changed_incomplete_relation_data(
@@ -186,7 +221,7 @@ def test_agent_relation_changed_download_jenkins_agent_fail(
     """
     arrange: given a monkeypatched download_jenkins_agent that raises AgentJarDownloadError.
     act: when _on_agent_relation_changed is called.
-    assert: the unit falls into ErroredStatus.
+    assert: the event is deferred and unit enters WaitingStatus.
     """
     (mock_event, relation_data) = get_event_relation_data(state.AGENT_RELATION)
     # The monkeypatched attribute download_jenkins_agent is used across unit tests.
@@ -195,6 +230,7 @@ def test_agent_relation_changed_download_jenkins_agent_fail(
         "download_jenkins_agent",
         lambda *_args, **_kwargs: raise_exception(server.AgentJarDownloadError),
     )
+    monkeypatch.setattr(server, "server_is_ready", lambda *_args, **_kwargs: True)
     harness.set_can_connect("jenkins-agent-k8s", True)
     relation_id = harness.add_relation(state.AGENT_RELATION, "jenkins")
     harness.add_relation_unit(relation_id, "jenkins/0")
@@ -206,10 +242,10 @@ def test_agent_relation_changed_download_jenkins_agent_fail(
     harness.begin()
 
     jenkins_charm = typing.cast(JenkinsAgentCharm, harness.charm)
-    with pytest.raises(server.AgentJarDownloadError) as exc:
-        jenkins_charm.agent_observer._on_agent_relation_changed(mock_event)
+    jenkins_charm.agent_observer._on_agent_relation_changed(mock_event)
 
-        assert exc.value == "Failed to download Jenkins agent executable."
+    assert jenkins_charm.unit.status.name == WAITING_STATUS_NAME
+    mock_event.defer.assert_called_once()
 
 
 def test_agent_relation_changed(
@@ -227,6 +263,7 @@ def test_agent_relation_changed(
     (mock_event, relation_data) = get_event_relation_data(state.AGENT_RELATION)
     monkeypatch.setattr(server, "download_jenkins_agent", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(server, "validate_credentials", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(server, "server_is_ready", lambda *_args, **_kwargs: True)
     harness.set_can_connect("jenkins-agent-k8s", True)
     relation_id = harness.add_relation(state.AGENT_RELATION, "jenkins")
     harness.add_relation_unit(relation_id, "jenkins/0")

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -107,25 +107,48 @@ def test_agent_relation_changed_container_not_ready(
     mock_event.defer.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "creds_changed,expect_active",
+    [
+        pytest.param(False, False, id="no_change"),
+        pytest.param(True, True, id="credentials_changed"),
+    ],
+)
 def test_agent_relation_changed_service_running(
     harness: ops.testing.Harness,
+    monkeypatch: pytest.MonkeyPatch,
     get_mock_relation_changed_event: typing.Callable[[str], unittest.mock.MagicMock],
+    creds_changed: bool,
+    expect_active: bool,
 ):
     """
     arrange: given a workload container with existing $JENKINS_HOME/agents/.ready file.
     act: when relation changed event is triggered.
-    assert: nothing happens since the agent is already registered.
+    assert: agent restarts only when credentials have changed.
     """
     mock_event = get_mock_relation_changed_event(state.AGENT_RELATION)
     harness.set_can_connect("jenkins-agent-k8s", True)
     container = harness.model.unit.get_container("jenkins-agent-k8s")
     container.push(server.AGENT_READY_PATH, "test", encoding="utf-8", make_dirs=True)
+    relation_id = harness.add_relation(state.AGENT_RELATION, "jenkins")
+    harness.add_relation_unit(relation_id, "jenkins/0")
+    harness.update_relation_data(
+        relation_id, "jenkins/0", {"url": "http://10.1.69.130:8080", "jenkins-agent-k8s-0_secret": "token123"}
+    )
+    monkeypatch.setattr(
+        pebble.PebbleService, "credentials_changed", lambda *_args, **_kwargs: creds_changed
+    )
+    monkeypatch.setattr(pebble.PebbleService, "stop_agent", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "download_jenkins_agent", lambda *_args, **_kwargs: None)
     harness.begin()
 
     jenkins_charm = typing.cast(JenkinsAgentCharm, harness.charm)
     jenkins_charm.agent_observer._on_agent_relation_changed(mock_event)
 
-    mock_event.defer.assert_not_called()
+    if expect_active:
+        assert jenkins_charm.unit.status.name == ACTIVE_STATUS_NAME
+    else:
+        mock_event.defer.assert_not_called()
 
 
 def test_agent_relation_changed_incomplete_relation_data(

--- a/tests/unit/test_pebble.py
+++ b/tests/unit/test_pebble.py
@@ -12,6 +12,7 @@ import unittest.mock
 
 import ops
 import ops.testing
+import pytest
 
 import pebble
 import server
@@ -99,3 +100,67 @@ def test_stop_agent():
 
     mock_container.stop.assert_called_once()
     mock_container.remove_path.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "plan_side_effect,services,server_url,agent_token,expected",
+    [
+        pytest.param(
+            ops.pebble.ConnectionError("not ready"),
+            None,
+            "http://new",
+            "token",
+            True,
+            id="no_plan",
+        ),
+        pytest.param(
+            None,
+            {},
+            "http://new",
+            "token",
+            True,
+            id="no_service",
+        ),
+        pytest.param(
+            None,
+            {"jenkins-agent-k8s": unittest.mock.MagicMock(
+                environment={"JENKINS_URL": "http://10.1.69.130:8080", "JENKINS_TOKEN": "secret123", "JENKINS_AGENT": "jenkins-agent-k8s-0"}
+            )},
+            "http://10.1.69.130:8080",
+            "secret123",
+            False,
+            id="same_credentials",
+        ),
+        pytest.param(
+            None,
+            {"jenkins-agent-k8s": unittest.mock.MagicMock(
+                environment={"JENKINS_URL": "http://10.1.69.130:8080", "JENKINS_TOKEN": "secret123", "JENKINS_AGENT": "jenkins-agent-k8s-0"}
+            )},
+            "http://10.1.69.153:8080",
+            "secret123",
+            True,
+            id="url_differs",
+        ),
+    ],
+)
+def test_credentials_changed(plan_side_effect, services, server_url, agent_token, expected):
+    """
+    arrange: given a container with varying pebble plan states.
+    act: when credentials_changed is called.
+    assert: returns expected result based on plan vs given credentials.
+    """
+    mock_state = unittest.mock.MagicMock(spec=state.State)
+    mock_state.jenkins_agent_service_name = "jenkins-agent-k8s"
+    mock_container = unittest.mock.MagicMock(spec=ops.Container)
+    if plan_side_effect:
+        mock_container.get_plan.side_effect = plan_side_effect
+    else:
+        mock_plan = unittest.mock.MagicMock()
+        mock_plan.services = services
+        mock_container.get_plan.return_value = mock_plan
+    pebble_service = pebble.PebbleService(state=mock_state)
+
+    result = pebble_service.credentials_changed(
+        container=mock_container, server_url=server_url, agent_token=agent_token
+    )
+    assert result is expected

--- a/tests/unit/test_pebble.py
+++ b/tests/unit/test_pebble.py
@@ -123,9 +123,15 @@ def test_stop_agent():
         ),
         pytest.param(
             None,
-            {"jenkins-agent-k8s": unittest.mock.MagicMock(
-                environment={"JENKINS_URL": "http://10.1.69.130:8080", "JENKINS_TOKEN": "secret123", "JENKINS_AGENT": "jenkins-agent-k8s-0"}
-            )},
+            {
+                "jenkins-agent-k8s": unittest.mock.MagicMock(
+                    environment={
+                        "JENKINS_URL": "http://10.1.69.130:8080",
+                        "JENKINS_TOKEN": "secret123",
+                        "JENKINS_AGENT": "jenkins-agent-k8s-0",
+                    }
+                )
+            },
             "http://10.1.69.130:8080",
             "secret123",
             False,
@@ -133,9 +139,15 @@ def test_stop_agent():
         ),
         pytest.param(
             None,
-            {"jenkins-agent-k8s": unittest.mock.MagicMock(
-                environment={"JENKINS_URL": "http://10.1.69.130:8080", "JENKINS_TOKEN": "secret123", "JENKINS_AGENT": "jenkins-agent-k8s-0"}
-            )},
+            {
+                "jenkins-agent-k8s": unittest.mock.MagicMock(
+                    environment={
+                        "JENKINS_URL": "http://10.1.69.130:8080",
+                        "JENKINS_TOKEN": "secret123",
+                        "JENKINS_AGENT": "jenkins-agent-k8s-0",
+                    }
+                )
+            },
             "http://10.1.69.153:8080",
             "secret123",
             True,

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -40,6 +40,49 @@ def test_download_jenkins_agent_download_error(
         server.download_jenkins_agent(server_url="http://test-url", container=mock_contaier)
 
 
+@pytest.mark.parametrize(
+    "status_code,expected",
+    [
+        pytest.param(200, True, id="login_ok"),
+        pytest.param(403, True, id="login_forbidden"),
+        pytest.param(503, False, id="service_unavailable"),
+    ],
+)
+def test_server_is_ready(
+    monkeypatch: pytest.MonkeyPatch, status_code: int, expected: bool
+):
+    """
+    arrange: given a monkeypatched requests.get that returns various status codes.
+    act: when server_is_ready is called.
+    assert: returns True only for 200/403.
+    """
+    mock_response = unittest.mock.MagicMock(spec=requests.Response)
+    mock_response.status_code = status_code
+    monkeypatch.setattr(requests, "get", lambda *_args, **_kwargs: mock_response)
+
+    assert server.server_is_ready("http://test-url") is expected
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(requests.ConnectionError, id="ConnectionError"),
+        pytest.param(requests.Timeout, id="Timeout"),
+    ],
+)
+def test_server_is_ready_connection_failure(
+    monkeypatch: pytest.MonkeyPatch, raise_exception: typing.Callable, exception: Exception
+):
+    """
+    arrange: given a monkeypatched requests.get that raises a connection error.
+    act: when server_is_ready is called.
+    assert: returns False.
+    """
+    monkeypatch.setattr(requests, "get", lambda *_args, **_kwargs: raise_exception(exception))
+
+    assert server.server_is_ready("http://test-url") is False
+
+
 def test_download_jenkins_agent_download(
     monkeypatch: pytest.MonkeyPatch, harness: ops.testing.Harness
 ):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -48,9 +48,7 @@ def test_download_jenkins_agent_download_error(
         pytest.param(503, False, id="service_unavailable"),
     ],
 )
-def test_server_is_ready(
-    monkeypatch: pytest.MonkeyPatch, status_code: int, expected: bool
-):
+def test_server_is_ready(monkeypatch: pytest.MonkeyPatch, status_code: int, expected: bool):
     """
     arrange: given a monkeypatched requests.get that returns various status codes.
     act: when server_is_ready is called.


### PR DESCRIPTION
## Summary

When `jenkins-k8s` is refreshed (e.g. `juju refresh --channel edge`), the new pod gets a different IP address. Previously, `_on_agent_relation_changed` checked only whether the `.ready` file existed and skipped entirely if so — even though the `JENKINS_URL` in the pebble plan was now stale. This left all agents permanently disconnected until a manual `remove-relation` + `re-relate` cycle.

## Root Cause

The agent-relation-changed hook logged "Given agent already registered. Skipping." without checking if the server URL in the pebble environment still matched the relation data.

## Changes

- **pebble.py**: Add `credentials_changed()` method that reads the pebble plan's environment and compares `JENKINS_URL` / `JENKINS_TOKEN` against the current relation data
- **agent.py**: When `.ready` exists, call `credentials_changed()`. If URL/token differ, stop agent and re-run `start_agent_from_relation` with new credentials. If unchanged, skip as before.
- **tests**: Replace single service_running test with two cases (no_change vs credentials_changed). Add 4 pebble unit tests for the new method.

## Testing

All 45 unit tests pass. Manually verified on microk8s:
1. Deployed jenkins-k8s rev 285 + jenkins-agent-k8s with 3 units
2. Confirmed all 3 agents online (48 executors)
3. Refreshed jenkins-k8s to rev 318 (new pod IP)
4. Without this fix: agents stuck offline. With fix: agents detect URL change and reconnect.